### PR TITLE
Add MCP server requirements and specs

### DIFF
--- a/docs/dev/mcp_integration.md
+++ b/docs/dev/mcp_integration.md
@@ -83,4 +83,8 @@ MCP bridges the gap between **interactive dialogue** and **structured knowledge 
 
 ---
 
+## Further Reading
+- [MCP Server/Container Requirements](mcp_integration/01_requirements.md)
+- [MCP Server Detailed Specifications](mcp_integration/02_specifications.md)
+
 This document serves as a conceptual specification for developers implementing MCP clients or servers in an IdeaMark-compatible environment.

--- a/docs/dev/mcp_integration/01_requirements.md
+++ b/docs/dev/mcp_integration/01_requirements.md
@@ -1,0 +1,17 @@
+# MCP Server/Container Requirements
+
+The MCP server is responsible for exposing IdeaMark pattern operations in a stateless, versioned manner. Requirements derive from [mcp_integration.md](../mcp_integration.md).
+
+## Functional
+- Provide endpoints for fetching, saving, validating and searching patterns as described in the conceptual doc.
+- Support generation of `.ref.yaml` files and pattern merges through dedicated actions.
+- Respect `access.visibility` flags when serving or storing content.
+- Operate on a git repository or local filesystem with a fallback strategy.
+
+## Operational
+- Should run inside a lightweight container image.
+- Must remain stateless between calls except for persistent storage of pattern files.
+- Version each endpoint and include metadata in responses.
+- Log whether content originates from human authors or AI agents.
+
+These requirements ensure the server can integrate cleanly with AI agents and tooling.

--- a/docs/dev/mcp_integration/02_specifications.md
+++ b/docs/dev/mcp_integration/02_specifications.md
@@ -1,0 +1,27 @@
+# MCP Server Detailed Specifications
+
+This document expands on the requirements in [01_requirements.md](01_requirements.md) and describes the API surface and flow for integrating IdeaMark with external agents.
+
+## API Endpoints
+- `GET /v1/pattern/{id}` – return a full YAML pattern.
+- `POST /v1/pattern/{id}` – save or update a pattern document.
+- `POST /v1/pattern/validate` – validate supplied YAML content.
+- `POST /v1/ref/generate` – produce a `.ref.yaml` from a pattern.
+- `POST /v1/pattern/merge` – merge multiple pattern IDs and return new content.
+- `GET /v1/pattern/search?q=<query>` – search refs by keyword or tag.
+
+Endpoints return JSON or YAML according to the `Accept` header and include a `version` field in each response.
+
+## Authentication
+- Use token-based authentication via the `Authorization` header.
+- Tokens may be scoped to read or write operations.
+- Requests without valid credentials should receive `401` responses.
+
+## Integration Flow
+1. The LLM session or tool calls `GET /pattern/{id}` to load an existing idea.
+2. User edits are validated via `POST /pattern/validate` before saving.
+3. Final content is stored using `POST /pattern/{id}`.
+4. A reference file can be generated with `POST /ref/generate`.
+5. When merging patterns, call `POST /pattern/merge` with a list of IDs.
+
+These specifications provide a consistent interface for agents and automation to interact with IdeaMark patterns through the MCP server.


### PR DESCRIPTION
## Summary
- establish `docs/dev/mcp_integration/` folder
- document high-level MCP server requirements
- detail API endpoints and integration flow
- point the conceptual doc to these files

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_6844f111cd7c8322835e9391683729a0