### PR TITLE
Update MCP docs

### DIFF
--- a/docs/dev/mcp_integration.md
+++ b/docs/dev/mcp_integration.md
@@ -19,6 +19,16 @@ MCP bridges the gap between **interactive dialogue** and **structured knowledge 
 - Assisted composition, comparison, and merge actions
 - Version-aware updates to public or restricted knowledge graphs
 
+## MCP Self-Descriptive Mechanisms
+
+MCP servers expose three categories of metadata so that agents can discover capabilities dynamically:
+
+- **Tools** – callable operations with names, descriptions and input schemas
+- **Resources** – URIs or contextual data the server can provide
+- **Prompts** – reusable instructions or templates for downstream LLM calls
+
+Clients typically retrieve these via `tools/list`, `resources/list`, and `prompts/list` RPC methods. A server might be written in Python with FastAPI, Deno with Oak, or Node.js with Express—the contract remains the same. This flexibility allows any runtime to plug into the IdeaMark workflow.
+
 ---
 
 ## Architecture

--- a/docs/dev/mcp_integration/01_requirements.md
+++ b/docs/dev/mcp_integration/01_requirements.md
@@ -2,6 +2,18 @@
 
 The MCP server is responsible for exposing IdeaMark pattern operations in a stateless, versioned manner that enables AI agents to interact with structured knowledge patterns. Requirements derive from [mcp_integration.md](../mcp_integration.md).
 
+## Self‑Descriptive Elements
+
+MCP servers advertise **Tools**, **Resources**, and **Prompts** so that clients can dynamically discover available capabilities. These elements are language‑agnostic – a server might be implemented in Python, Node.js, Deno, or any other runtime. Clients use `tools/list`, `resources/list`, and `prompts/list` RPC methods to obtain metadata about available functions and data sources before invoking them.
+
+```
+GET /mcp/tools/list    → returns callable tool definitions
+GET /mcp/resources/list → lists accessible URIs or context blobs
+GET /mcp/prompts/list  → exposes reusable prompt templates
+```
+
+This self‑description is central to MCP’s flexibility. For example, a Node.js server could return a set of JavaScript functions with JSON schemas for input, while a Python server could expose the same functionality via asyncio coroutines. Agents decide which tool to call based on these definitions rather than hard‑coded endpoints.
+
 ## Functional Requirements
 
 ### Core Pattern Operations

--- a/docs/dev/mcp_integration/02_specifications.md
+++ b/docs/dev/mcp_integration/02_specifications.md
@@ -1,6 +1,6 @@
 # MCP Server Technical Specifications
 
-This document provides detailed technical specifications for implementing the MCP server based on the requirements in [01_requirements.md](01_requirements.md).
+This document provides detailed technical specifications for implementing the MCP server based on the requirements in [01_requirements.md](01_requirements.md).  The code samples below use Python for clarity, but any language capable of serving JSON-RPC (for example Node.js or Deno) can implement the same endpoints.
 
 ## API Endpoint Specifications
 
@@ -470,6 +470,17 @@ if errors:
     return {"validation": {"valid": False, "errors": errors}}
 ```
 
+An implementation written in TypeScript might use a comparable validation library:
+
+```ts
+import { validatePattern } from "./lib/validators.ts";
+
+const errors = validatePattern(patternData);
+if (errors.length) {
+  return { validation: { valid: false, errors } };
+}
+```
+
 **LLM Provider Integration**:
 ```python
 from tools.src.llm.providers import create_llm_provider
@@ -479,6 +490,17 @@ if llm_provider:
     synthesis_result = llm_provider.generate(merge_prompt)
 ```
 
+The same concept can be expressed in JavaScript using a different SDK:
+
+```js
+import { createLlmProvider } from './lib/llm.js';
+
+const provider = createLlmProvider('openai', config);
+if (provider) {
+  const synthesisResult = await provider.generate(mergePrompt);
+}
+```
+
 **Configuration Management**:
 ```python
 from tools.src.utils.config import Config
@@ -486,6 +508,15 @@ from tools.src.utils.config import Config
 config = Config()
 github_token = os.getenv('GITHUB_TOKEN')
 llm_config = config.get_llm_config('openai')
+```
+
+In a Deno environment configuration might be loaded with environment utilities:
+
+```ts
+import { config as loadEnv } from "https://deno.land/std/dotenv/mod.ts";
+
+const env = await loadEnv();
+const githubToken = env["GITHUB_TOKEN"];
 ```
 
 ### External Service Integration
@@ -533,6 +564,18 @@ COPY . .
 EXPOSE 8000
 
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+```
+
+If you prefer a JavaScript runtime, a comparable container might use a Node.js or Deno base image:
+
+```dockerfile
+FROM denoland/deno:latest
+WORKDIR /app
+COPY deps.ts .
+RUN deno cache deps.ts
+COPY . .
+EXPOSE 8000
+CMD ["deno", "run", "--allow-env", "--allow-net", "main.ts"]
 ```
 
 **Environment Variables**:


### PR DESCRIPTION
## Summary
- document self-descriptive MCP elements
- clarify runtime agnostic approach in requirements
- mention Node.js/Deno alternatives in technical spec

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684520e8d55c8322a1f416e64ae9e039