### PR TITLE
Add MCP metadata listing endpoints

### DIFF
--- a/tools/src/mcp_server/api/mcp_metadata.py
+++ b/tools/src/mcp_server/api/mcp_metadata.py
@@ -1,0 +1,118 @@
+from fastapi import APIRouter
+from typing import Dict, Any, List
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
+
+from storage.local_storage import LocalStorage
+from utils.config import load_prompts
+from utils.logging import get_logger
+
+logger = get_logger('mcp_metadata')
+router = APIRouter()
+
+storage = LocalStorage()
+
+
+def _get_tools() -> List[Dict[str, Any]]:
+    return [
+        {
+            "operation": "pattern.fetch",
+            "method": "GET",
+            "path": "/v1/pattern/{pattern_id}",
+            "description": "Retrieve a pattern by ID",
+        },
+        {
+            "operation": "pattern.save",
+            "method": "POST",
+            "path": "/v1/pattern/{pattern_id}",
+            "description": "Save or update a pattern",
+        },
+        {
+            "operation": "pattern.validate",
+            "method": "POST",
+            "path": "/v1/pattern/validate",
+            "description": "Validate pattern content against the schema",
+        },
+        {
+            "operation": "ref.generate",
+            "method": "POST",
+            "path": "/v1/ref/generate",
+            "description": "Generate a .ref.yaml from pattern content",
+        },
+        {
+            "operation": "pattern.merge",
+            "method": "POST",
+            "path": "/v1/pattern/merge",
+            "description": "Merge multiple patterns together",
+        },
+        {
+            "operation": "pattern.search",
+            "method": "GET",
+            "path": "/v1/pattern/search",
+            "description": "Search available pattern references",
+        },
+    ]
+
+
+@router.get("/mcp/tools/list")
+async def list_tools() -> Dict[str, Any]:
+    """Return metadata describing available MCP operations.
+
+    Example response:
+    {
+        "tools": [
+            {"operation": "pattern.fetch", "method": "GET", "path": "/v1/pattern/{pattern_id}"},
+            {"operation": "pattern.save", "method": "POST", "path": "/v1/pattern/{pattern_id}"}
+        ]
+    }
+    """
+    return {"tools": _get_tools()}
+
+
+@router.get("/mcp/resources/list")
+async def list_resources() -> Dict[str, Any]:
+    """List pattern and reference resources accessible from this server.
+
+    Example response:
+    {
+        "patterns": [
+            {"id": "urban-waste-recycling-logistics", "title": "Urban waste recycling logistics"}
+        ],
+        "refs": [
+            {"id": "urban-waste-recycling-logistics", "title": "Urban waste recycling logistics"}
+        ]
+    }
+    """
+    patterns = [
+        {"id": p.get("id"), "title": p.get("title", "")}
+        for p in storage.list_all_patterns()
+    ]
+    refs = [
+        {
+            "id": r.get("ref", {}).get("id"),
+            "title": r.get("ref", {}).get("title", ""),
+        }
+        for r in storage.list_all_refs()
+    ]
+    return {"patterns": patterns, "refs": refs}
+
+
+@router.get("/mcp/prompts/list")
+async def list_prompts() -> Dict[str, Any]:
+    """Return available prompt templates for LLM operations.
+
+    Example response:
+    {
+        "prompts": [
+            {"name": "problem_summary", "template": "Combine the following IdeaMark problem summaries..."}
+        ]
+    }
+    """
+    prompts = load_prompts()
+    prompt_list = [
+        {"name": name, "template": template}
+        for name, template in prompts.items()
+    ]
+    return {"prompts": prompt_list}

--- a/tools/src/mcp_server/main.py
+++ b/tools/src/mcp_server/main.py
@@ -12,6 +12,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from api.patterns import router as patterns_router
 from api.health import router as health_router
+from api.mcp_metadata import router as metadata_router
 from auth.jwt_auth import get_current_user
 from utils.logging import get_logger
 from utils.config import Config
@@ -37,6 +38,7 @@ def create_app() -> FastAPI:
     
     app.include_router(health_router, prefix="", tags=["health"])
     app.include_router(patterns_router, prefix="/v1", tags=["patterns"])
+    app.include_router(metadata_router, prefix="", tags=["metadata"])
     
     @app.exception_handler(HTTPException)
     async def http_exception_handler(request: Request, exc: HTTPException):

--- a/tools/src/mcp_server/standalone_server.py
+++ b/tools/src/mcp_server/standalone_server.py
@@ -14,6 +14,10 @@ import time
 from pathlib import Path
 from typing import Dict, Any, List, Optional
 import logging
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+from api.mcp_metadata import router as metadata_router
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("mcp_server")
@@ -203,6 +207,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.include_router(metadata_router, prefix="", tags=["metadata"])
 
 start_time = time.time()
 request_count = 0

--- a/tools/src/mcp_server/storage/local_storage.py
+++ b/tools/src/mcp_server/storage/local_storage.py
@@ -82,7 +82,7 @@ class LocalStorage:
     
     def list_all_refs(self) -> List[Dict[str, Any]]:
         refs = []
-        
+
         try:
             for ref_file in self.refs_dir.glob("*.ref.yaml"):
                 with open(ref_file, 'r') as f:
@@ -91,8 +91,23 @@ class LocalStorage:
         except Exception as e:
             logger.error(f"Failed to list refs: {e}")
             raise
-        
+
         return refs
+
+    def list_all_patterns(self) -> List[Dict[str, Any]]:
+        """Return all patterns stored on disk."""
+        patterns = []
+
+        try:
+            for pattern_file in self.patterns_dir.glob("*.yaml"):
+                with open(pattern_file, 'r') as f:
+                    pattern_data = yaml.safe_load(f)
+                    patterns.append(pattern_data)
+        except Exception as e:
+            logger.error(f"Failed to list patterns: {e}")
+            raise
+
+        return patterns
     
     def pattern_exists(self, pattern_id: str) -> bool:
         pattern_path = self.patterns_dir / f"{pattern_id}.yaml"


### PR DESCRIPTION
## Summary
- expose new `/mcp` metadata endpoints
- load patterns from storage
- register metadata router in both server entry points
- support listing patterns from LocalStorage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68453427ff208322835b4fe5227c0273