### PR TITLE
Add ChatGPT MCP connection docs

### DIFF
--- a/tools/src/mcp_server/README.md
+++ b/tools/src/mcp_server/README.md
@@ -164,3 +164,24 @@ The server provides structured logging and health checks:
 - Access control based on pattern visibility
 - Environment variable based secret management
 - CORS configuration for cross-origin requests
+
+## Connecting to ChatGPT via MCP
+
+To connect ChatGPT with this server, set `MCP_SERVER_URL` (or a similarly named variable) in your ChatGPT tool configuration to the base URL of the MCP server. During initialization ChatGPT will call `\<MCP_SERVER_URL>/tools/list` to discover available tools.
+
+You can generate a development JWT for testing:
+
+```python
+from mcp_server.auth.jwt_auth import create_dev_token
+
+token = create_dev_token("chatgpt-dev", admin=True)
+print(token)
+```
+
+Include the token when ChatGPT or any client makes requests:
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8000/v1/pattern/example
+```
+
+See the [OpenAI MCP documentation](https://platform.openai.com/docs/assistants/mcp) for more details.


### PR DESCRIPTION
## Summary
- document how to connect ChatGPT with the MCP server
- include dev JWT example and OpenAI doc link

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_6845342ed88c8322bc18e846fee952cc