### PR TITLE
Add OAuth2 login flow to MCP server

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -9,3 +9,4 @@ uvicorn>=0.24.0
 python-jose[cryptography]>=3.3.0
 python-multipart>=0.0.6
 pydantic>=2.0.0
+authlib>=1.2.0

--- a/tools/src/mcp_server/README.md
+++ b/tools/src/mcp_server/README.md
@@ -24,6 +24,8 @@ A Docker-based Model Context Protocol (MCP) server for IdeaMark pattern operatio
 
 ### Health & Monitoring
 - `GET /health` - Health check with dependency status
+- `GET /oauth/login` - Redirect to OAuth provider
+- `GET /oauth/callback` - Exchange code for token
 
 ## Quick Start
 
@@ -40,6 +42,11 @@ pip install -r requirements.txt
 export WORK_DIR=/tmp/mcp_data
 export JWT_SECRET_KEY=dev-secret-key
 export LOG_LEVEL=INFO
+export OAUTH_CLIENT_ID=your-client-id
+export OAUTH_CLIENT_SECRET=your-client-secret
+export OAUTH_AUTHORIZATION_URL=https://provider.example/auth
+export OAUTH_TOKEN_URL=https://provider.example/token
+export OAUTH_REDIRECT_URI=http://localhost:8000/oauth/callback
 ```
 
 3. **Run the server**:
@@ -82,6 +89,11 @@ docker run -d \
 | `CORS_ORIGINS` | `*` | CORS allowed origins |
 | `HOST` | `0.0.0.0` | Server bind host |
 | `PORT` | `8000` | Server port |
+| `OAUTH_CLIENT_ID` | | OAuth client ID |
+| `OAUTH_CLIENT_SECRET` | | OAuth client secret |
+| `OAUTH_AUTHORIZATION_URL` | | OAuth authorization endpoint |
+| `OAUTH_TOKEN_URL` | | OAuth token endpoint |
+| `OAUTH_REDIRECT_URI` | | Redirect URI registered with provider |
 
 ## Authentication
 
@@ -91,6 +103,15 @@ The server supports JWT token authentication. For local development, you can gen
 from mcp_server.auth.jwt_auth import create_dev_token
 token = create_dev_token("dev-user", admin=True)
 print(f"Authorization: Bearer {token}")
+```
+
+You can also authenticate via an external OAuth provider. Set the OAuth environment
+variables above, then visit `/oauth/login` to begin the flow. After completing
+authorization the server returns a JWT and sets an `access_token` cookie.
+Example command line login using `curl`:
+
+```bash
+curl -L http://localhost:8000/oauth/login
 ```
 
 ## Storage Structure

--- a/tools/src/mcp_server/api/patterns.py
+++ b/tools/src/mcp_server/api/patterns.py
@@ -5,7 +5,7 @@ import os
 import uuid
 from datetime import datetime
 
-from auth.jwt_auth import get_current_user
+from auth import get_current_user
 from storage.local_storage import LocalStorage
 from models.pattern_models import (
     PatternResponse,

--- a/tools/src/mcp_server/auth/__init__.py
+++ b/tools/src/mcp_server/auth/__init__.py
@@ -1,0 +1,17 @@
+from fastapi import Depends, Request
+from fastapi.security import HTTPAuthorizationCredentials
+from typing import Optional, Dict, Any
+
+from .jwt_auth import get_current_user as get_jwt_user, security
+from .oauth import get_current_oauth_user
+
+
+async def get_current_user(
+    request: Request,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+) -> Dict[str, Any]:
+    """Resolve the current user via OAuth cookie or JWT header."""
+    oauth_user = await get_current_oauth_user(request)
+    if oauth_user.get("authenticated"):
+        return oauth_user
+    return await get_jwt_user(credentials)

--- a/tools/src/mcp_server/auth/oauth.py
+++ b/tools/src/mcp_server/auth/oauth.py
@@ -1,0 +1,89 @@
+from fastapi import APIRouter, Request, HTTPException, Depends, status
+from fastapi.responses import RedirectResponse, JSONResponse
+from fastapi.security import OAuth2AuthorizationCodeBearer
+from authlib.integrations.starlette_client import OAuth, OAuthError
+import os
+from typing import Dict, Any, Optional
+
+from .jwt_auth import create_access_token, verify_token, security
+
+router = APIRouter()
+
+OAUTH_CLIENT_ID = os.getenv("OAUTH_CLIENT_ID")
+OAUTH_CLIENT_SECRET = os.getenv("OAUTH_CLIENT_SECRET")
+OAUTH_AUTH_URL = os.getenv("OAUTH_AUTHORIZATION_URL")
+OAUTH_TOKEN_URL = os.getenv("OAUTH_TOKEN_URL")
+OAUTH_REDIRECT_URI = os.getenv("OAUTH_REDIRECT_URI")
+OAUTH_SCOPE = os.getenv("OAUTH_SCOPE", "openid profile email")
+
+
+# OAuth client using Authlib
+_oauth = OAuth()
+_oauth.register(
+    name="default",
+    client_id=OAUTH_CLIENT_ID,
+    client_secret=OAUTH_CLIENT_SECRET,
+    access_token_url=OAUTH_TOKEN_URL,
+    authorize_url=OAUTH_AUTH_URL,
+    client_kwargs={"scope": OAUTH_SCOPE},
+)
+
+
+def get_oauth_client():
+    """Return configured OAuth client."""
+    return _oauth.create_client("default")
+
+
+@router.get("/oauth/login")
+async def login_redirect(request: Request):
+    """Redirect user to external authorization server."""
+    client = get_oauth_client()
+    redirect_uri = OAUTH_REDIRECT_URI
+    return await client.authorize_redirect(request, redirect_uri)
+
+
+@router.get("/oauth/callback")
+async def oauth_callback(request: Request):
+    """Handle OAuth provider callback and issue JWT."""
+    client = get_oauth_client()
+    try:
+        token = await client.authorize_access_token(request)
+        user = await client.parse_id_token(request, token)
+    except OAuthError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    jwt_token = create_access_token({"sub": user.get("sub")})
+    response = JSONResponse({"access_token": jwt_token, "token_type": "bearer"})
+    response.set_cookie("access_token", jwt_token, httponly=True)
+    return response
+
+
+oauth_scheme = OAuth2AuthorizationCodeBearer(
+    authorizationUrl="/oauth/login",
+    tokenUrl="/oauth/callback",
+    auto_error=False,
+)
+
+
+async def get_current_oauth_user(
+    request: Request,
+    token: Optional[str] = Depends(oauth_scheme),
+) -> Dict[str, Any]:
+    """Retrieve current user from OAuth cookie or Authorization header."""
+    if not token:
+        token = request.cookies.get("access_token")
+    if not token:
+        return {"sub": "anonymous", "admin": False, "authenticated": False}
+
+    try:
+        payload = verify_token(token)
+        return {
+            "sub": payload.get("sub"),
+            "admin": payload.get("admin", False),
+            "authenticated": True,
+            "exp": payload.get("exp"),
+        }
+    except HTTPException:
+        raise
+    except Exception:
+        return {"sub": "anonymous", "admin": False, "authenticated": False}

--- a/tools/src/mcp_server/main.py
+++ b/tools/src/mcp_server/main.py
@@ -8,16 +8,18 @@ from datetime import datetime
 from typing import Dict, Any
 import logging
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from api.patterns import router as patterns_router
 from api.health import router as health_router
 from api.mcp_metadata import router as metadata_router
-from auth.jwt_auth import get_current_user
+from auth import get_current_user
+from auth.oauth import router as oauth_router
 from utils.logging import get_logger
 from utils.config import Config
 
-logger = get_logger('mcp_server')
+logger = get_logger("mcp_server")
+
 
 def create_app() -> FastAPI:
     app = FastAPI(
@@ -25,9 +27,9 @@ def create_app() -> FastAPI:
         description="Model Context Protocol server for IdeaMark pattern operations",
         version="1.0.0",
         docs_url="/docs",
-        redoc_url="/redoc"
+        redoc_url="/redoc",
     )
-    
+
     app.add_middleware(
         CORSMiddleware,
         allow_origins=os.getenv("CORS_ORIGINS", "*").split(","),
@@ -35,11 +37,12 @@ def create_app() -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
-    
+
     app.include_router(health_router, prefix="", tags=["health"])
     app.include_router(patterns_router, prefix="/v1", tags=["patterns"])
     app.include_router(metadata_router, prefix="", tags=["metadata"])
-    
+    app.include_router(oauth_router, prefix="", tags=["oauth"])
+
     @app.exception_handler(HTTPException)
     async def http_exception_handler(request: Request, exc: HTTPException):
         return JSONResponse(
@@ -48,11 +51,11 @@ def create_app() -> FastAPI:
                 "error": {
                     "code": exc.status_code,
                     "message": exc.detail,
-                    "timestamp": datetime.utcnow().isoformat() + "Z"
+                    "timestamp": datetime.utcnow().isoformat() + "Z",
                 }
-            }
+            },
         )
-    
+
     @app.exception_handler(Exception)
     async def general_exception_handler(request: Request, exc: Exception):
         logger.error(f"Unhandled exception: {exc}")
@@ -62,12 +65,13 @@ def create_app() -> FastAPI:
                 "error": {
                     "code": 500,
                     "message": "Internal server error",
-                    "timestamp": datetime.utcnow().isoformat() + "Z"
+                    "timestamp": datetime.utcnow().isoformat() + "Z",
                 }
-            }
+            },
         )
-    
+
     return app
+
 
 app = create_app()
 
@@ -75,11 +79,5 @@ if __name__ == "__main__":
     port = int(os.getenv("PORT", 8000))
     host = os.getenv("HOST", "0.0.0.0")
     log_level = os.getenv("LOG_LEVEL", "info").lower()
-    
-    uvicorn.run(
-        "main:app",
-        host=host,
-        port=port,
-        log_level=log_level,
-        reload=False
-    )
+
+    uvicorn.run("main:app", host=host, port=port, log_level=log_level, reload=False)


### PR DESCRIPTION
## Summary
- add `authlib` to requirements
- implement OAuth2 Authorization Code flow helper and routes
- aggregate auth logic in `auth/__init__.py`
- update API to use new `get_current_user`
- wire OAuth router into FastAPI app
- document OAuth setup and usage

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68453c3355608322b10cbc79fb6a20e7