### PR TITLE
Add OAuth configuration support

### DIFF
--- a/tools/config/default.yaml
+++ b/tools/config/default.yaml
@@ -24,7 +24,15 @@ logging:
   format: "[%(asctime)s] [%(levelname)s] [%(name)s] %(message)s"
   console: true
   file: false
-  
+
 output:
   create_summary: true
   validate_output: true
+
+oauth:
+  client_id: ${OAUTH_CLIENT_ID}
+  client_secret: ${OAUTH_CLIENT_SECRET}
+  authorization_url: https://provider.example.com/auth
+  token_url: https://provider.example.com/token
+  redirect_uri: http://localhost:8000/oauth/callback
+  scope: 'openid profile email'

--- a/tools/src/mcp_server/README.md
+++ b/tools/src/mcp_server/README.md
@@ -79,6 +79,8 @@ docker run -d \
 | `JWT_ALGORITHM` | `HS256` | JWT algorithm |
 | `JWT_EXPIRATION_HOURS` | `24` | Token expiration time |
 | `LOG_LEVEL` | `INFO` | Logging level |
+| `OAUTH_CLIENT_ID` | | OAuth client ID |
+| `OAUTH_CLIENT_SECRET` | | OAuth client secret |
 | `CORS_ORIGINS` | `*` | CORS allowed origins |
 | `HOST` | `0.0.0.0` | Server bind host |
 | `PORT` | `8000` | Server port |

--- a/tools/src/utils/config.py
+++ b/tools/src/utils/config.py
@@ -3,16 +3,19 @@ import os
 from pathlib import Path
 from typing import Dict, Any
 
+
 class Config:
     def __init__(self, config_path: str = None):
         if config_path is None:
-            config_path = Path(__file__).parent.parent.parent / "config" / "default.yaml"
-        
-        with open(config_path, 'r') as f:
+            config_path = (
+                Path(__file__).parent.parent.parent / "config" / "default.yaml"
+            )
+
+        with open(config_path, "r") as f:
             self._config = yaml.safe_load(f)
-    
+
     def get(self, key: str, default: Any = None) -> Any:
-        keys = key.split('.')
+        keys = key.split(".")
         value = self._config
         for k in keys:
             if isinstance(value, dict) and k in value:
@@ -20,21 +23,42 @@ class Config:
             else:
                 return default
         return value
-    
+
     def get_llm_config(self, provider: str) -> Dict[str, Any]:
-        return self.get(f'llm.providers.{provider}', {})
-    
+        return self.get(f"llm.providers.{provider}", {})
+
     def get_network_config(self) -> Dict[str, Any]:
-        return self.get('network', {})
-    
+        return self.get("network", {})
+
     def get_logging_config(self) -> Dict[str, Any]:
-        return self.get('logging', {})
+        return self.get("logging", {})
+
+    def get_oauth_config(self) -> Dict[str, Any]:
+        oauth_config = self.get("oauth", {})
+        expanded = {}
+        for key, value in oauth_config.items():
+            if (
+                isinstance(value, str)
+                and value.startswith("${")
+                and value.endswith("}")
+            ):
+                env_var = value[2:-1]
+                expanded[key] = os.getenv(env_var, "")
+            else:
+                expanded[key] = value
+        return expanded
+
 
 def load_prompts(prompts_path: str = None) -> Dict[str, str]:
     if prompts_path is None:
-        prompts_path = Path(__file__).parent.parent.parent / "config" / "prompts" / "synthesis.yaml"
-    
-    with open(prompts_path, 'r') as f:
+        prompts_path = (
+            Path(__file__).parent.parent.parent
+            / "config"
+            / "prompts"
+            / "synthesis.yaml"
+        )
+
+    with open(prompts_path, "r") as f:
         prompts = yaml.safe_load(f)
-    
-    return prompts.get('synthesis', {})
+
+    return prompts.get("synthesis", {})


### PR DESCRIPTION
## Summary
- extend default config with oauth section
- expose `get_oauth_config` helper
- document OAuth environment variables in MCP server README

## Testing
- `black tools/src/utils/config.py`
- `flake8 tools/src/utils/config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68453c39cfec8322904d07f1a9a5f21c