### PR TITLE
Add OAuth authentication docs

### DIFF
--- a/tools/src/mcp_server/README.md
+++ b/tools/src/mcp_server/README.md
@@ -93,6 +93,29 @@ token = create_dev_token("dev-user", admin=True)
 print(f"Authorization: Bearer {token}")
 ```
 
+## OAuth Authentication
+
+You can also authenticate via an external OAuth2 provider. After login the
+provider returns an access token, which is used the same as a JWT token in
+`Authorization: Bearer` headers.
+
+Set your OAuth credentials:
+
+```bash
+export OAUTH_CLIENT_ID=my-client-id
+export OAUTH_CLIENT_SECRET=my-secret
+export OAUTH_ISSUER_URL=https://auth.example.com
+```
+
+Initiate the login flow from your application:
+
+```python
+import webbrowser
+
+auth_url = f"{OAUTH_ISSUER_URL}/authorize?client_id={OAUTH_CLIENT_ID}&response_type=token"
+webbrowser.open(auth_url)
+```
+
 ## Storage Structure
 
 The `WORK_DIR` contains:


### PR DESCRIPTION
## Summary
- document OAuth login next to JWT instructions in MCP server README

## Testing
- `pytest --maxfail=1 -q`
- `black tools/src/mcp_server --check` *(fails: would reformat files)*
- `flake8 tools/src/mcp_server` *(fails with style errors)*

------
https://chatgpt.com/codex/tasks/task_b_68453c3fde5c832297c31241ad47d9f9