### PR TITLE
Add no-auth option for MCP server

### DIFF
--- a/tools/src/mcp_server/README.md
+++ b/tools/src/mcp_server/README.md
@@ -42,6 +42,7 @@ pip install -r requirements.txt
 export WORK_DIR=/tmp/mcp_data
 export JWT_SECRET_KEY=dev-secret-key
 export LOG_LEVEL=INFO
+export AUTH_DISABLED=true  # disable auth for local testing
 export OAUTH_CLIENT_ID=your-client-id
 export OAUTH_CLIENT_SECRET=your-client-secret
 export OAUTH_AUTHORIZATION_URL=https://provider.example/auth
@@ -85,6 +86,7 @@ docker run -d \
 | `JWT_SECRET_KEY` | `dev-secret-key` | JWT signing secret |
 | `JWT_ALGORITHM` | `HS256` | JWT algorithm |
 | `JWT_EXPIRATION_HOURS` | `24` | Token expiration time |
+| `AUTH_DISABLED` | `false` | Set to `true` to disable authentication |
 | `LOG_LEVEL` | `INFO` | Logging level |
 | `OAUTH_CLIENT_ID` | | OAuth client ID |
 | `OAUTH_CLIENT_SECRET` | | OAuth client secret |
@@ -98,6 +100,8 @@ docker run -d \
 | `OAUTH_REDIRECT_URI` | | Redirect URI registered with provider |
 
 ## Authentication
+
+Authentication defaults to JWT or OAuth tokens. To disable all authentication (useful for local ChatGPT integration), set `AUTH_DISABLED=true`.
 
 The server supports JWT token authentication. For local development, you can generate a dev token:
 

--- a/tools/src/mcp_server/auth/__init__.py
+++ b/tools/src/mcp_server/auth/__init__.py
@@ -1,6 +1,9 @@
 from fastapi import Depends, Request
 from fastapi.security import HTTPAuthorizationCredentials
 from typing import Optional, Dict, Any
+import os
+
+AUTH_DISABLED = os.getenv("AUTH_DISABLED", "false").lower() in ["1", "true", "yes"]
 
 from .jwt_auth import get_current_user as get_jwt_user, security
 from .oauth import get_current_oauth_user
@@ -10,7 +13,12 @@ async def get_current_user(
     request: Request,
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
 ) -> Dict[str, Any]:
-    """Resolve the current user via OAuth cookie or JWT header."""
+    """Resolve the current user via OAuth cookie, JWT header, or return an
+    anonymous admin user if authentication is disabled."""
+
+    if AUTH_DISABLED:
+        return {"sub": "anonymous", "admin": True, "authenticated": False}
+
     oauth_user = await get_current_oauth_user(request)
     if oauth_user.get("authenticated"):
         return oauth_user


### PR DESCRIPTION
## Summary
- allow disabling auth by `AUTH_DISABLED` env var
- document the new env var in MCP server README

## Testing
- `python -m pytest src/mcp_server/tests/` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_b_68453e6a39948322aeebe1acce7f9e55