### PR TITLE
Update LLM services list

### DIFF
--- a/docs/dev/mcp_integration/01_requirements.md
+++ b/docs/dev/mcp_integration/01_requirements.md
@@ -79,7 +79,7 @@ This self‑description is central to MCP’s flexibility. For example, a Node.j
 
 #### External Service Integration
 - **GitHub API**: Support GitHub repository access with token authentication
-- **LLM Services**: Compatible with OpenAI, Anthropic, and local LLM endpoints
+- **LLM Services**: Compatible with OpenAI, Anthropic, Mistral, Google (Gemini), and local LLM endpoints; dynamic provider selection enables adding new providers via configuration
 - **File Systems**: Support both local and network-mounted storage backends
 - **Monitoring**: Integration with standard observability tools (Prometheus, Grafana)
 


### PR DESCRIPTION
## Summary
- expand the LLM services bullet to include Mistral and Gemini
- note that new providers can be configured dynamically

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68454851b60c8322890f4ff9d9eb6933