### PR TITLE
Update LLM provider docs

### DIFF
--- a/docs/dev/mcp_integration/02_specifications.md
+++ b/docs/dev/mcp_integration/02_specifications.md
@@ -544,6 +544,12 @@ llm:
     anthropic:
       api_key: "${ANTHROPIC_API_KEY}"
       model: "claude-3-sonnet-20240229"
+    mistral:
+      api_key: "${MISTRAL_API_KEY}"
+      model: "mistral-large"
+    google:
+      api_key: "${GOOGLE_API_KEY}"
+      model: "gemini-pro"
 ```
 
 ## Deployment Architecture
@@ -592,11 +598,22 @@ GITHUB_API_URL=https://api.github.com
 # LLM Providers
 OPENAI_API_KEY=sk-your-key-here
 ANTHROPIC_API_KEY=sk-ant-your-key-here
+MISTRAL_API_KEY=sk-mistral-your-key
+GOOGLE_API_KEY=sk-google-your-key
 
 # Server Configuration
 LOG_LEVEL=INFO
 CORS_ORIGINS=*
 API_VERSION=1.0
+```
+
+To select a specific LLM backend at startup, set the `LLM_PROVIDER` environment
+variable (or pass a comparable CLI flag) to one of the keys defined under
+`llm.providers`. For example:
+
+```bash
+export LLM_PROVIDER=mistral
+python standalone_server.py
 ```
 
 ### Health Checks


### PR DESCRIPTION
## Summary
- document placeholder settings for Mistral and Google LLM providers
- note new `MISTRAL_API_KEY` and `GOOGLE_API_KEY` variables
- show how to select a provider via the `LLM_PROVIDER` environment variable

## Testing
- `pip install -q -r tools/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6845485b091c8322a1a5d05b22488668