### PR TITLE
Add Mistral and Google LLM defaults

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -190,7 +190,15 @@ llm:
       model: claude-3-sonnet-20240229
       max_tokens: 2000
       temperature: 0.3
-  fallback_strategy: manual
+    mistral:
+      model: mistral-medium
+      max_tokens: 2000
+      temperature: 0.3
+    google:
+      model: gemini-pro
+      max_tokens: 2000
+      temperature: 0.3
+    fallback_strategy: manual
   
 network:
   retries: 3

--- a/tools/config/default.yaml
+++ b/tools/config/default.yaml
@@ -12,6 +12,14 @@ llm:
       model: claude-3-sonnet-20240229
       max_tokens: 2000
       temperature: 0.3
+    mistral:
+      model: mistral-medium
+      max_tokens: 2000
+      temperature: 0.3
+    google:
+      model: gemini-pro
+      max_tokens: 2000
+      temperature: 0.3
   fallback_strategy: manual
   
 network:


### PR DESCRIPTION
## Summary
- include new `mistral` and `google` provider sections in the default LLM config
- document the new providers in the tools README

## Testing
- `python tools/src/mcp_server/simple_test.py` *(fails: No module named 'fastapi')*
- `python -m py_compile tools/validate_output.py`


------
https://chatgpt.com/codex/tasks/task_b_684548631be48322bc6b3e0de591d779