### PR TITLE
Add requirements file for mcp_server

### DIFF
--- a/tools/src/mcp_server/requirements.txt
+++ b/tools/src/mcp_server/requirements.txt
@@ -1,0 +1,12 @@
+PyYAML>=6.0
+requests>=2.28.0
+jsonschema>=4.17.0
+openai>=1.0.0
+anthropic>=0.7.0
+click>=8.1.0
+fastapi>=0.104.0
+uvicorn>=0.24.0
+python-jose[cryptography]>=3.3.0
+python-multipart>=0.0.6
+pydantic>=2.0.0
+authlib>=1.2.0


### PR DESCRIPTION
## Summary
- add missing requirements.txt for the MCP server Docker build

## Testing
- `pip install -r tools/src/mcp_server/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6845555f80688322ad787975deca36e4