### PR TITLE
Fix Docker build context for MCP server

### DIFF
--- a/tools/src/mcp_server/Dockerfile
+++ b/tools/src/mcp_server/Dockerfile
@@ -2,11 +2,14 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-COPY requirements.txt .
+COPY tools/src/mcp_server/requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+# Copy the entire source tree so shared modules like `utils` are present
+COPY tools/src/ /app
+
+ENV PYTHONPATH=/app
 
 EXPOSE 8000
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "mcp_server.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/tools/src/mcp_server/README.md
+++ b/tools/src/mcp_server/README.md
@@ -64,8 +64,8 @@ python -m uvicorn main:app --host 0.0.0.0 --port 8000 --reload
 
 1. **Build the container**:
 ```bash
-cd tools/src/mcp_server
-docker build -t ideamark-mcp-server .
+# Run from the repository root so shared modules are included
+docker build -f tools/src/mcp_server/Dockerfile -t ideamark-mcp-server .
 ```
 
 2. **Run with environment variables**:
@@ -238,8 +238,8 @@ uses the provided Dockerfile.
 
 1. **Build the Docker image**
    ```bash
-   cd tools/src/mcp_server
-   docker build -t ideamark-mcp-server .
+   # Build from the repository root so all modules are copied
+   docker build -f tools/src/mcp_server/Dockerfile -t ideamark-mcp-server .
    ```
 
 2. **Run the server with API keys**


### PR DESCRIPTION
## Summary
- ensure Docker build copies shared modules
- update README build instructions

## Testing
- `python -m pytest tools/src/mcp_server/simple_test.py -q`
- `python -m pytest tools/src/mcp_server/test_api.py -vv`
- `python -m pytest tools/src/mcp_server/test_imports.py -vv`


------
https://chatgpt.com/codex/tasks/task_b_68455b77026c8322888cec20c61fd91b