### PR TITLE
Fix module imports for MCP server

### DIFF
--- a/tools/src/mcp_server/api/patterns.py
+++ b/tools/src/mcp_server/api/patterns.py
@@ -5,7 +5,7 @@ import os
 import uuid
 from datetime import datetime
 
-from auth import get_current_user
+from mcp_server.auth import get_current_user
 from storage.local_storage import LocalStorage
 from models.pattern_models import (
     PatternResponse,

--- a/tools/src/mcp_server/main.py
+++ b/tools/src/mcp_server/main.py
@@ -10,11 +10,11 @@ import logging
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from api.patterns import router as patterns_router
-from api.health import router as health_router
-from api.mcp_metadata import router as metadata_router
-from auth import get_current_user
-from auth.oauth import router as oauth_router
+from mcp_server.api.patterns import router as patterns_router
+from mcp_server.api.health import router as health_router
+from mcp_server.api.mcp_metadata import router as metadata_router
+from mcp_server.auth import get_current_user
+from mcp_server.auth.oauth import router as oauth_router
 from utils.logging import get_logger
 from utils.config import Config
 

--- a/tools/src/mcp_server/standalone_server.py
+++ b/tools/src/mcp_server/standalone_server.py
@@ -17,7 +17,7 @@ import logging
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
-from api.mcp_metadata import router as metadata_router
+from mcp_server.api.mcp_metadata import router as metadata_router
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("mcp_server")

--- a/tools/src/mcp_server/test_imports.py
+++ b/tools/src/mcp_server/test_imports.py
@@ -6,10 +6,10 @@ sys.path.insert(0, '/home/ubuntu/repos/ideamark-core/tools/src')
 
 def test_imports():
     try:
-        from main import app
+        from mcp_server.main import app
         print("✓ FastAPI app created successfully")
         
-        from auth.jwt_auth import create_dev_token
+        from mcp_server.auth.jwt_auth import create_dev_token
         token = create_dev_token("test-user", admin=True)
         print(f"✓ JWT token created: {token[:20]}...")
         


### PR DESCRIPTION
## Summary
- fix imports in MCP server package to use `mcp_server` prefix
- update standalone server and utility scripts

## Testing
- `pip install -r tools/src/mcp_server/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684572a280c883228f13ef852d9e4b6b