### PR TITLE
Standardize lib package imports

### DIFF
--- a/docs/dev/mcp_integration/02_specifications.md
+++ b/docs/dev/mcp_integration/02_specifications.md
@@ -569,7 +569,7 @@ COPY . .
 
 EXPOSE 8000
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "lib.mcp_server.main:app", "--host", "0.0.0.0", "--port", "8000"]
 ```
 
 If you prefer a JavaScript runtime, a comparable container might use a Node.js or Deno base image:

--- a/lib/mcp_server/Dockerfile
+++ b/lib/mcp_server/Dockerfile
@@ -5,11 +5,11 @@ WORKDIR /app
 COPY lib/mcp_server/requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy the entire source tree so shared modules like `utils` are present
-COPY lib/ /app
+# Copy the entire repository so the package structure under `lib` is preserved
+COPY . /app
 
 ENV PYTHONPATH=/app
 
 EXPOSE 8000
 
-CMD ["uvicorn", "mcp_server.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "lib.mcp_server.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/lib/mcp_server/README.md
+++ b/lib/mcp_server/README.md
@@ -46,8 +46,7 @@ cp .env.example .env
 
 3. **Run the server**:
 ```bash
-cd lib/mcp_server
-python -m uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+python -m uvicorn lib.mcp_server.main:app --host 0.0.0.0 --port 8000 --reload
 ```
 
 4. **Access the API**:
@@ -104,7 +103,7 @@ Authentication defaults to JWT or OAuth tokens. To disable all authentication (u
 The server supports JWT token authentication. For local development, you can generate a dev token:
 
 ```python
-from mcp_server.auth.jwt_auth import create_dev_token
+from lib.mcp_server.auth.jwt_auth import create_dev_token
 token = create_dev_token("dev-user", admin=True)
 print(f"Authorization: Bearer {token}")
 ```
@@ -210,7 +209,7 @@ To connect ChatGPT, Claude, or any other chat-based LLM with this server, set `M
 You can generate a development JWT for testing:
 
 ```python
-from mcp_server.auth.jwt_auth import create_dev_token
+from lib.mcp_server.auth.jwt_auth import create_dev_token
 
 token = create_dev_token("chat-client-dev", admin=True)
 print(token)
@@ -250,7 +249,7 @@ uses the provided Dockerfile.
 3. **Create a development token**
    ```bash
    TOKEN=$(docker run --rm ideamark-mcp-server python - <<'PY'
-from mcp_server.auth.jwt_auth import create_dev_token
+from lib.mcp_server.auth.jwt_auth import create_dev_token
 print(create_dev_token("llm-test", admin=True))
 PY
 )

--- a/lib/mcp_server/api/health.py
+++ b/lib/mcp_server/api/health.py
@@ -2,11 +2,9 @@ from fastapi import APIRouter, HTTPException
 from datetime import datetime
 import os
 import time
-import sys
 from typing import Dict, Any
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
-from utils.logging import get_logger
+from ...utils.logging import get_logger
 
 logger = get_logger('health')
 router = APIRouter()

--- a/lib/mcp_server/api/mcp_metadata.py
+++ b/lib/mcp_server/api/mcp_metadata.py
@@ -1,13 +1,10 @@
 from fastapi import APIRouter
 from typing import Dict, Any, List
 import os
-import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
-
-from storage.local_storage import LocalStorage
-from utils.config import load_prompts
-from utils.logging import get_logger
+from ..storage.local_storage import LocalStorage
+from ...utils.config import load_prompts
+from ...utils.logging import get_logger
 
 logger = get_logger('mcp_metadata')
 router = APIRouter()

--- a/lib/mcp_server/api/patterns.py
+++ b/lib/mcp_server/api/patterns.py
@@ -5,24 +5,20 @@ import os
 import uuid
 from datetime import datetime
 
-from mcp_server.auth import get_current_user
-from storage.local_storage import LocalStorage
-from models.pattern_models import (
+from ..auth import get_current_user
+from ..storage.local_storage import LocalStorage
+from ..models.pattern_models import (
     PatternResponse,
     PatternValidationResponse,
     RefGenerationResponse,
     PatternMergeResponse,
     PatternSearchResponse,
 )
-import sys
-import os
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
-from merge.validators import PatternValidator, validate_ref_structure
-from merge.core import PatternMerger
-from io.pattern_loader import PatternLoader
-from utils.config import Config
-from utils.logging import get_logger
+from ...merge.validators import PatternValidator, validate_ref_structure
+from ...merge.core import PatternMerger
+from ...io.pattern_loader import PatternLoader
+from ...utils.config import Config
+from ...utils.logging import get_logger
 
 logger = get_logger("patterns_api")
 router = APIRouter()

--- a/lib/mcp_server/auth/jwt_auth.py
+++ b/lib/mcp_server/auth/jwt_auth.py
@@ -3,11 +3,9 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from jose import JWTError, jwt
 from datetime import datetime, timedelta
 import os
-import sys
 from typing import Dict, Any, Optional
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
-from utils.logging import get_logger
+from ...utils.logging import get_logger
 
 logger = get_logger('jwt_auth')
 

--- a/lib/mcp_server/main.py
+++ b/lib/mcp_server/main.py
@@ -3,20 +3,17 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 import uvicorn
 import os
-import sys
 from datetime import datetime
 from typing import Dict, Any
 import logging
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-
-from mcp_server.api.patterns import router as patterns_router
-from mcp_server.api.health import router as health_router
-from mcp_server.api.mcp_metadata import router as metadata_router
-from mcp_server.auth import get_current_user
-from mcp_server.auth.oauth import router as oauth_router
-from utils.logging import get_logger
-from utils.config import Config
+from .api.patterns import router as patterns_router
+from .api.health import router as health_router
+from .api.mcp_metadata import router as metadata_router
+from .auth import get_current_user
+from .auth.oauth import router as oauth_router
+from ..utils.logging import get_logger
+from ..utils.config import Config
 
 logger = get_logger("mcp_server")
 
@@ -80,4 +77,4 @@ if __name__ == "__main__":
     host = os.getenv("HOST", "0.0.0.0")
     log_level = os.getenv("LOG_LEVEL", "info").lower()
 
-    uvicorn.run("main:app", host=host, port=port, log_level=log_level, reload=False)
+    uvicorn.run("lib.mcp_server.main:app", host=host, port=port, log_level=log_level, reload=False)

--- a/lib/mcp_server/standalone_server.py
+++ b/lib/mcp_server/standalone_server.py
@@ -14,10 +14,8 @@ import time
 from pathlib import Path
 from typing import Dict, Any, List, Optional
 import logging
-import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
-from mcp_server.api.mcp_metadata import router as metadata_router
+from .api.mcp_metadata import router as metadata_router
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("mcp_server")

--- a/lib/mcp_server/storage/local_storage.py
+++ b/lib/mcp_server/storage/local_storage.py
@@ -1,11 +1,9 @@
 import os
 import yaml
-import sys
 from pathlib import Path
 from typing import Dict, Any, List, Optional
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
-from utils.logging import get_logger
+from ...utils.logging import get_logger
 
 logger = get_logger('local_storage')
 

--- a/lib/mcp_server/test_imports.py
+++ b/lib/mcp_server/test_imports.py
@@ -5,24 +5,24 @@ import os
 from pathlib import Path
 
 # Allow running this test from anywhere
-root_dir = Path(__file__).resolve().parent.parent
+root_dir = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(root_dir / "lib"))
 sys.path.insert(0, str(root_dir))
 
 def test_imports():
     try:
-        from mcp_server.main import app
+        from lib.mcp_server.main import app
         print("✓ FastAPI app created successfully")
         
-        from mcp_server.auth.jwt_auth import create_dev_token
+        from lib.mcp_server.auth.jwt_auth import create_dev_token
         token = create_dev_token("test-user", admin=True)
         print(f"✓ JWT token created: {token[:20]}...")
         
-        from storage.local_storage import LocalStorage
+        from lib.mcp_server.storage.local_storage import LocalStorage
         storage = LocalStorage("/tmp/test")
         print("✓ Local storage initialized")
         
-        from models.pattern_models import PatternResponse
+        from lib.mcp_server.models.pattern_models import PatternResponse
         print("✓ Pattern models imported")
         
         print("All imports successful!")

--- a/lib/merge/validators.py
+++ b/lib/merge/validators.py
@@ -9,7 +9,7 @@ logger = get_logger('validators')
 class PatternValidator:
     def __init__(self, schema_path: str = None):
         if schema_path is None:
-            schema_path = Path(__file__).parent.parent.parent.parent / "schema" / "ideamark.schema.yaml"
+            schema_path = Path(__file__).resolve().parents[2] / "schema" / "ideamark.schema.yaml"
         
         with open(schema_path, 'r') as f:
             self.schema = yaml.safe_load(f)


### PR DESCRIPTION
## Summary
- update MCP server modules to use relative imports within the `lib` package
- adjust default schema path in validators
- update Dockerfile and documentation to run `uvicorn lib.mcp_server.main:app`
- fix helper tests for new package path

## Testing
- `python -m compileall -q lib/mcp_server`
- `python lib/mcp_server/test_imports.py`
- `python lib/mcp_server/simple_test.py`


------
https://chatgpt.com/codex/tasks/task_b_68476555ab90832295746b1527076a64