### PR TITLE
Align MCP server routes with /mcp/v1 standard

### DIFF
--- a/docs/dev/mcp_integration/01_requirements.md
+++ b/docs/dev/mcp_integration/01_requirements.md
@@ -7,9 +7,9 @@ The MCP server is responsible for exposing IdeaMark pattern operations in a stat
 MCP servers advertise **Tools**, **Resources**, and **Prompts** so that clients can dynamically discover available capabilities. These elements are language‑agnostic – a server might be implemented in Python, Node.js, Deno, or any other runtime. Clients use `tools/list`, `resources/list`, and `prompts/list` RPC methods to obtain metadata about available functions and data sources before invoking them.
 
 ```
-GET /mcp/tools/list    → returns callable tool definitions
-GET /mcp/resources/list → lists accessible URIs or context blobs
-GET /mcp/prompts/list  → exposes reusable prompt templates
+GET /mcp/v1/tools/list    → returns callable tool definitions
+GET /mcp/v1/resources/list → lists accessible URIs or context blobs
+GET /mcp/v1/prompts/list  → exposes reusable prompt templates
 ```
 
 This self‑description is central to MCP’s flexibility. For example, a Node.js server could return a set of JavaScript functions with JSON schemas for input, while a Python server could expose the same functionality via asyncio coroutines. Agents decide which tool to call based on these definitions rather than hard‑coded endpoints.

--- a/docs/dev/mcp_integration/02_specifications.md
+++ b/docs/dev/mcp_integration/02_specifications.md
@@ -6,7 +6,7 @@ This document provides detailed technical specifications for implementing the MC
 
 ### 1. Pattern Retrieval: `pattern.fetch(id)`
 
-**Endpoint**: `GET /v1/pattern/{id}`
+**Endpoint**: `GET /mcp/v1/pattern/{id}`
 
 **Description**: Retrieve a complete pattern by its unique identifier.
 
@@ -62,7 +62,7 @@ This document provides detailed technical specifications for implementing the MC
 
 ### 2. Pattern Storage: `pattern.save(id, content)`
 
-**Endpoint**: `POST /v1/pattern/{id}`
+**Endpoint**: `POST /mcp/v1/pattern/{id}`
 
 **Description**: Save or update a pattern with validation and access control.
 
@@ -125,7 +125,7 @@ This document provides detailed technical specifications for implementing the MC
 
 ### 3. Pattern Validation: `pattern.validate(content)`
 
-**Endpoint**: `POST /v1/pattern/validate`
+**Endpoint**: `POST /mcp/v1/pattern/validate`
 
 **Description**: Validate pattern content against the IdeaMark schema without saving.
 
@@ -189,7 +189,7 @@ This document provides detailed technical specifications for implementing the MC
 
 ### 4. Reference Generation: `ref.generate(pattern)`
 
-**Endpoint**: `POST /v1/ref/generate`
+**Endpoint**: `POST /mcp/v1/ref/generate`
 
 **Description**: Generate a `.ref.yaml` file from pattern content with proper metadata.
 
@@ -251,7 +251,7 @@ This document provides detailed technical specifications for implementing the MC
 
 ### 5. Pattern Merging: `pattern.merge([ids])`
 
-**Endpoint**: `POST /v1/pattern/merge`
+**Endpoint**: `POST /mcp/v1/pattern/merge`
 
 **Description**: Merge multiple patterns using configurable strategies and LLM assistance.
 
@@ -323,7 +323,7 @@ This document provides detailed technical specifications for implementing the MC
 
 ### 6. Pattern Search: `pattern.search(query)`
 
-**Endpoint**: `GET /v1/pattern/search`
+**Endpoint**: `GET /mcp/v1/pattern/search`
 
 **Description**: Search patterns by keywords, tags, or metadata with relevance ranking.
 

--- a/lib/mcp_server/README.md
+++ b/lib/mcp_server/README.md
@@ -13,14 +13,14 @@ A Docker-based Model Context Protocol (MCP) server for IdeaMark pattern operatio
 ## API Endpoints
 
 ### Pattern Operations
-- `GET /v1/pattern/{id}` - Fetch pattern by ID
-- `POST /v1/pattern/{id}` - Save/update pattern
-- `POST /v1/pattern/validate` - Validate pattern schema compliance
-- `POST /v1/pattern/merge` - Merge multiple patterns
-- `GET /v1/pattern/search` - Search patterns with filters
+- `GET /mcp/v1/pattern/{id}` - Fetch pattern by ID
+- `POST /mcp/v1/pattern/{id}` - Save/update pattern
+- `POST /mcp/v1/pattern/validate` - Validate pattern schema compliance
+- `POST /mcp/v1/pattern/merge` - Merge multiple patterns
+- `GET /mcp/v1/pattern/search` - Search patterns with filters
 
 ### Reference Operations
-- `POST /v1/ref/generate` - Auto-generate .ref.yaml from pattern
+- `POST /mcp/v1/ref/generate` - Auto-generate .ref.yaml from pattern
 
 ### Health & Monitoring
 - `GET /health` - Health check with dependency status
@@ -149,7 +149,7 @@ The `WORK_DIR` contains:
 ### Fetch Pattern
 ```bash
 curl -H "Authorization: Bearer YOUR_TOKEN" \
-  http://localhost:8000/v1/pattern/IdeaMark-123
+  http://localhost:8000/mcp/v1/pattern/IdeaMark-123
 ```
 
 ### Validate Pattern
@@ -158,12 +158,12 @@ curl -X POST \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_TOKEN" \
   -d '{"content": {"id": "test", "title": "Test Pattern"}}' \
-  http://localhost:8000/v1/pattern/validate
+  http://localhost:8000/mcp/v1/pattern/validate
 ```
 
 ### Search Patterns
 ```bash
-curl "http://localhost:8000/v1/pattern/search?q=authentication&type=security&limit=5" \
+curl "http://localhost:8000/mcp/v1/pattern/search?q=authentication&type=security&limit=5" \
   -H "Authorization: Bearer YOUR_TOKEN"
 ```
 
@@ -218,7 +218,7 @@ print(token)
 Include the token when your chat client makes requests:
 
 ```bash
-curl -H "Authorization: Bearer $TOKEN" http://localhost:8000/v1/pattern/example
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8000/mcp/v1/pattern/example
 ```
 
 See the [OpenAI MCP documentation](https://platform.openai.com/docs/mcp) for more details.
@@ -256,23 +256,23 @@ PY
    ```
 
 4. **Send test requests**
-   After saving two patterns, call `/v1/pattern/merge` with `strategy=synthesis`.
+   After saving two patterns, call `/mcp/v1/pattern/merge` with `strategy=synthesis`.
    The response should include a `merged_content` field produced by the chosen LLM.
    ```bash
    curl -X POST -H "Content-Type: application/json" \
         -H "Authorization: Bearer $TOKEN" \
         -d '{"content":{"id":"A","title":"Pattern A","problem":{"summary":"A"},"solution":{"approach":"A"}}}' \
-        http://localhost:8000/v1/pattern/A
+        http://localhost:8000/mcp/v1/pattern/A
 
    curl -X POST -H "Content-Type: application/json" \
         -H "Authorization: Bearer $TOKEN" \
         -d '{"content":{"id":"B","title":"Pattern B","problem":{"summary":"B"},"solution":{"approach":"B"}}}' \
-        http://localhost:8000/v1/pattern/B
+        http://localhost:8000/mcp/v1/pattern/B
 
    curl -X POST -H "Content-Type: application/json" \
         -H "Authorization: Bearer $TOKEN" \
         -d '{"pattern_ids":["A","B"],"strategy":"synthesis"}' \
-        http://localhost:8000/v1/pattern/merge
+        http://localhost:8000/mcp/v1/pattern/merge
    ```
 
 5. **Stop the container** when you are done:

--- a/lib/mcp_server/api/health.py
+++ b/lib/mcp_server/api/health.py
@@ -46,3 +46,20 @@ async def health_check() -> Dict[str, Any]:
             "average_response_time_ms": 150
         }
     }
+
+
+@router.get("/mcp/v1/ping")
+async def ping() -> Dict[str, Any]:
+    """Lightweight health ping for MCP clients."""
+    return {"status": "ok", "timestamp": datetime.utcnow().isoformat() + "Z"}
+
+
+@router.get("/mcp/v1/initialize")
+async def initialize() -> Dict[str, Any]:
+    """Return basic server info for MCP initialization."""
+    return {
+        "status": "initialized",
+        "server": "IdeaMark MCP Server",
+        "version": "1.0.0",
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+    }

--- a/lib/mcp_server/api/mcp_metadata.py
+++ b/lib/mcp_server/api/mcp_metadata.py
@@ -17,58 +17,58 @@ def _get_tools() -> List[Dict[str, Any]]:
         {
             "operation": "pattern.fetch",
             "method": "GET",
-            "path": "/v1/pattern/{pattern_id}",
+            "path": "/mcp/v1/pattern/{pattern_id}",
             "description": "Retrieve a pattern by ID",
         },
         {
             "operation": "pattern.save",
             "method": "POST",
-            "path": "/v1/pattern/{pattern_id}",
+            "path": "/mcp/v1/pattern/{pattern_id}",
             "description": "Save or update a pattern",
         },
         {
             "operation": "pattern.validate",
             "method": "POST",
-            "path": "/v1/pattern/validate",
+            "path": "/mcp/v1/pattern/validate",
             "description": "Validate pattern content against the schema",
         },
         {
             "operation": "ref.generate",
             "method": "POST",
-            "path": "/v1/ref/generate",
+            "path": "/mcp/v1/ref/generate",
             "description": "Generate a .ref.yaml from pattern content",
         },
         {
             "operation": "pattern.merge",
             "method": "POST",
-            "path": "/v1/pattern/merge",
+            "path": "/mcp/v1/pattern/merge",
             "description": "Merge multiple patterns together",
         },
         {
             "operation": "pattern.search",
             "method": "GET",
-            "path": "/v1/pattern/search",
+            "path": "/mcp/v1/pattern/search",
             "description": "Search available pattern references",
         },
     ]
 
 
-@router.get("/mcp/tools/list")
+@router.get("/mcp/v1/tools/list")
 async def list_tools() -> Dict[str, Any]:
     """Return metadata describing available MCP operations.
 
     Example response:
     {
         "tools": [
-            {"operation": "pattern.fetch", "method": "GET", "path": "/v1/pattern/{pattern_id}"},
-            {"operation": "pattern.save", "method": "POST", "path": "/v1/pattern/{pattern_id}"}
+            {"operation": "pattern.fetch", "method": "GET", "path": "/mcp/v1/pattern/{pattern_id}"},
+            {"operation": "pattern.save", "method": "POST", "path": "/mcp/v1/pattern/{pattern_id}"}
         ]
     }
     """
     return {"tools": _get_tools()}
 
 
-@router.get("/mcp/resources/list")
+@router.get("/mcp/v1/resources/list")
 async def list_resources() -> Dict[str, Any]:
     """List pattern and reference resources accessible from this server.
 
@@ -96,7 +96,7 @@ async def list_resources() -> Dict[str, Any]:
     return {"patterns": patterns, "refs": refs}
 
 
-@router.get("/mcp/prompts/list")
+@router.get("/mcp/v1/prompts/list")
 async def list_prompts() -> Dict[str, Any]:
     """Return available prompt templates for LLM operations.
 

--- a/lib/mcp_server/main.py
+++ b/lib/mcp_server/main.py
@@ -36,7 +36,7 @@ def create_app() -> FastAPI:
     )
 
     app.include_router(health_router, prefix="", tags=["health"])
-    app.include_router(patterns_router, prefix="/v1", tags=["patterns"])
+    app.include_router(patterns_router, prefix="/mcp/v1", tags=["patterns"])
     app.include_router(metadata_router, prefix="", tags=["metadata"])
     app.include_router(oauth_router, prefix="", tags=["oauth"])
 

--- a/lib/mcp_server/standalone_server.py
+++ b/lib/mcp_server/standalone_server.py
@@ -267,7 +267,7 @@ async def health_check() -> Dict[str, Any]:
     }
 
 
-@app.get("/v1/pattern/{pattern_id}", response_model=PatternResponse)
+@app.get("/mcp/v1/pattern/{pattern_id}", response_model=PatternResponse)
 async def fetch_pattern(
     pattern_id: str, user: Dict[str, Any] = Depends(get_current_user)
 ):
@@ -293,7 +293,7 @@ async def fetch_pattern(
     )
 
 
-@app.post("/v1/pattern/{pattern_id}", response_model=PatternResponse)
+@app.post("/mcp/v1/pattern/{pattern_id}", response_model=PatternResponse)
 async def save_pattern_endpoint(
     pattern_id: str,
     request: PatternSaveRequest,
@@ -320,7 +320,7 @@ async def save_pattern_endpoint(
     )
 
 
-@app.post("/v1/pattern/validate", response_model=PatternValidationResponse)
+@app.post("/mcp/v1/pattern/validate", response_model=PatternValidationResponse)
 async def validate_pattern_endpoint(
     request: PatternValidateRequest, user: Dict[str, Any] = Depends(get_current_user)
 ):
@@ -344,7 +344,7 @@ async def validate_pattern_endpoint(
     )
 
 
-@app.post("/v1/ref/generate", response_model=RefGenerationResponse)
+@app.post("/mcp/v1/ref/generate", response_model=RefGenerationResponse)
 async def generate_ref(
     request: RefGenerateRequest, user: Dict[str, Any] = Depends(get_current_user)
 ):
@@ -394,7 +394,7 @@ async def generate_ref(
     )
 
 
-@app.post("/v1/pattern/merge", response_model=PatternMergeResponse)
+@app.post("/mcp/v1/pattern/merge", response_model=PatternMergeResponse)
 async def merge_patterns(
     request: PatternMergeRequest, user: Dict[str, Any] = Depends(get_current_user)
 ):
@@ -455,7 +455,7 @@ async def merge_patterns(
     )
 
 
-@app.get("/v1/pattern/search", response_model=PatternSearchResponse)
+@app.get("/mcp/v1/pattern/search", response_model=PatternSearchResponse)
 async def search_patterns(
     q: str = Query(..., description="Search query"),
     type: Optional[str] = Query(None, description="Filter by pattern type"),

--- a/lib/mcp_server/test_api.py
+++ b/lib/mcp_server/test_api.py
@@ -59,7 +59,7 @@ def test_mcp_server():
 
     try:
         response = requests.post(
-            f"{base_url}/v1/pattern/validate",
+            f"{base_url}/mcp/v1/pattern/validate",
             headers=headers,
             json={"content": test_pattern},
         )
@@ -78,7 +78,7 @@ def test_mcp_server():
     print("\n3. Testing pattern save...")
     try:
         response = requests.post(
-            f"{base_url}/v1/pattern/test-pattern-123",
+            f"{base_url}/mcp/v1/pattern/test-pattern-123",
             headers=headers,
             json={"content": test_pattern},
         )
@@ -96,7 +96,7 @@ def test_mcp_server():
     print("\n4. Testing pattern fetch...")
     try:
         response = requests.get(
-            f"{base_url}/v1/pattern/test-pattern-123", headers=headers
+            f"{base_url}/mcp/v1/pattern/test-pattern-123", headers=headers
         )
         print(f"Pattern fetch: {response.status_code}")
         if response.status_code == 200:
@@ -112,7 +112,7 @@ def test_mcp_server():
     print("\n5. Testing ref generation...")
     try:
         response = requests.post(
-            f"{base_url}/v1/ref/generate",
+            f"{base_url}/mcp/v1/ref/generate",
             headers=headers,
             json={"pattern": test_pattern},
         )
@@ -130,7 +130,7 @@ def test_mcp_server():
     print("\n6. Testing pattern search...")
     try:
         response = requests.get(
-            f"{base_url}/v1/pattern/search?q=test&limit=5", headers=headers
+            f"{base_url}/mcp/v1/pattern/search?q=test&limit=5", headers=headers
         )
         print(f"Pattern search: {response.status_code}")
         if response.status_code == 200:
@@ -156,7 +156,7 @@ def test_mcp_server():
 
     try:
         response = requests.post(
-            f"{base_url}/v1/pattern/test-pattern-456",
+            f"{base_url}/mcp/v1/pattern/test-pattern-456",
             headers=headers,
             json={"content": test_pattern_2},
         )
@@ -167,7 +167,7 @@ def test_mcp_server():
 
     try:
         response = requests.post(
-            f"{base_url}/v1/ref/generate",
+            f"{base_url}/mcp/v1/ref/generate",
             headers=headers,
             json={"pattern": test_pattern_2},
         )
@@ -178,7 +178,7 @@ def test_mcp_server():
 
     try:
         response = requests.post(
-            f"{base_url}/v1/pattern/merge",
+            f"{base_url}/mcp/v1/pattern/merge",
             headers=headers,
             json={
                 "pattern_ids": ["test-pattern-123", "test-pattern-456"],


### PR DESCRIPTION
## Summary
- update server route prefixes to `/mcp/v1`
- add `/mcp/v1/ping` and `/mcp/v1/initialize` endpoints
- update metadata listing paths
- adjust docs and examples for new routes
- update tests and standalone server to use new paths

## Testing
- `python lib/mcp_server/simple_test.py`
- `python lib/mcp_server/test_imports.py`


------
https://chatgpt.com/codex/tasks/task_b_68476e58c6d88322a1d4ae6407457394