### PR TITLE
Add range, granularity, reference, and evidence fields

### DIFF
--- a/docs/format_guides.md
+++ b/docs/format_guides.md
@@ -43,8 +43,22 @@ metadata:
     spacemetrics: "urban neighborhood"
     regions: ["Shikoku"]
     organizations: ["city council"]
-```
+range:
+  spatial: local
+  temporal: short-term
+  social_scope: community
+granularity:
+  level: strategic
+reference:
+  - label: Local Health Ordinance
+    url: https://example.org/health-ordinance
+    type: legal
+evidence:
+  - type: observation
+    description: Data collected from local clinic usage
+    url: https://example.org/clinic-data
 
+```
 **Tips:**
 - Keep field names lowercase and snake_case
 - Use plain strings or simple arrays — avoid deep nesting

--- a/docs/schema_design.md
+++ b/docs/schema_design.md
@@ -64,6 +64,33 @@ This allows AI and humans alike to:
 
 ---
 
+## Range, Granularity, Reference & Evidence
+
+These optional fields further specify scope and credibility:
+
+```yaml
+range:
+  spatial: regional
+  temporal: mid-term
+  social_scope: community
+
+granularity:
+  level: implementation
+  description: Optional note on why this level was chosen
+
+reference:
+  - label: JIS Z 8111
+    url: https://example.org/jis-z-8111
+    type: standard
+
+evidence:
+  - type: case-study
+    description: Supporting data or observation
+    url: https://example.org/example-evidence
+```
+
+Use them to clarify how broad or detailed the pattern is, cite standards, and attach evidence.
+
 ## URI & Access Model
 
 Each IdeaMark carries:

--- a/patterns/remote-island-telemedicine.yaml
+++ b/patterns/remote-island-telemedicine.yaml
@@ -21,6 +21,21 @@ metadata:
     organizations:
     - regional hospitals
     - local clinics
+range:
+  spatial: regional
+  temporal: mid-term
+  social_scope: community
+granularity:
+  level: implementation
+  description: Deployment details for telemedicine hubs
+reference:
+  - label: WHO Telemedicine Guidelines
+    url: https://www.who.int/publications/i/item/9789240018329
+    type: standard
+evidence:
+  - type: case-study
+    description: Okinawa remote islands telemedicine success
+    url: https://example.org/okinawa-case-study
 access:
   uri: https://github.com/ak2i/ideamark-core/blob/main/patterns/remote-island-telemedicine.yaml
   visibility: public

--- a/schema/ideamark.schema.yaml
+++ b/schema/ideamark.schema.yaml
@@ -92,6 +92,83 @@ properties:
             type: array
             items:
               type: string
+  range:
+    type: object
+    properties:
+      spatial:
+        type: string
+        enum:
+        - global
+        - national
+        - regional
+        - local
+        - site-specific
+      temporal:
+        type: string
+        enum:
+        - long-term
+        - mid-term
+        - short-term
+      social_scope:
+        type: string
+        enum:
+        - individual
+        - group
+        - organization
+        - community
+        - society
+        - civilization
+  granularity:
+    type: object
+    properties:
+      level:
+        type: string
+        enum:
+        - conceptual
+        - strategic
+        - tactical
+        - operational
+        - implementation
+      description:
+        type: string
+  reference:
+    type: array
+    items:
+      type: object
+      properties:
+        label:
+          type: string
+        url:
+          type: string
+          format: uri
+        type:
+          type: string
+          enum:
+          - standard
+          - glossary
+          - academic
+          - legal
+      required:
+      - label
+      - url
+  evidence:
+    type: array
+    items:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+          - case-study
+          - dataset
+          - experiment
+          - citation
+          - observation
+        description:
+          type: string
+        url:
+          type: string
+          format: uri
   usage_scenarios:
     type: array
     items:


### PR DESCRIPTION
## Summary
- extend IdeaMark schema with optional `range`, `granularity`, `reference`, and `evidence` fields
- demonstrate the new fields in the `remote-island-telemedicine` example pattern
- document the additional fields in `schema_design.md` and `format_guides.md`

## Testing
- `python test_health.py`
- `python test_jwt.py`


------
https://chatgpt.com/codex/tasks/task_b_685f05f43ee08322ac240ac057309f69