### PR TITLE
Add extended analysis fields

### DIFF
--- a/docs/analysis_extensions.md
+++ b/docs/analysis_extensions.md
@@ -1,0 +1,63 @@
+# Extended Analysis Fields
+
+IdeaMark allows optional structures to capture progress and operational metrics for tasks or projects.
+These fields are especially useful for `project-analysis` or `work-review` documents.
+
+## timeline / statusHistory
+
+```yaml
+timeline:
+  - entity: task:product-release
+    year: 2023
+    milestone: "\u4ed5\u69d8\u78ba\u5b9a"
+    status: delayed
+```
+
+Record annual events or status changes for any task or organizational unit.
+
+## dependencies / blockers
+
+```yaml
+dependencies:
+  - from: task:design
+    to: task:implementation
+    type: sequential
+    risk: medium
+```
+
+Declare relationships or blockers between tasks to clarify scheduling risk.
+
+## observed_metrics
+
+```yaml
+observed_metrics:
+  - entity: task:delivery
+    metric: response_time
+    average: "5d"
+    stdev: "2d"
+```
+
+Store measured KPIs or process metrics as part of the pattern record.
+
+## patterns / anti-patterns
+
+```yaml
+patterns:
+  - type: delayed-decision
+    occurred_in: ["task:x", "task:y"]
+    severity: high
+```
+
+Capture recurring patterns or anti-patterns observed during execution.
+
+## hypotheses / questions
+
+```yaml
+hypotheses:
+  - text: "\u3053\u306e\u9045\u5ef6\u306f\u8a2d\u8a08\u5de5\u7a0b\u306e\u5c5e\u4eba\u6027\u304c\u539f\u56e0\u3067\u3042\u308b\u53ef\u80fd\u6027\u304c\u9ad8\u3044"
+    confidence: 0.7
+```
+
+Use hypotheses to state possible causes or open questions along with a confidence score.
+
+These fields complement existing metadata and can be mixed and matched as needed.

--- a/docs/format_guides.md
+++ b/docs/format_guides.md
@@ -57,6 +57,28 @@ evidence:
   - type: observation
     description: Data collected from local clinic usage
     url: https://example.org/clinic-data
+timeline:
+  - entity: task:product-release
+    year: 2023
+    milestone: "\u4ed5\u69d8\u78ba\u5b9a"
+    status: delayed
+dependencies:
+  - from: task:design
+    to: task:implementation
+    type: sequential
+    risk: medium
+observed_metrics:
+  - entity: task:delivery
+    metric: response_time
+    average: "5d"
+    stdev: "2d"
+patterns:
+  - type: delayed-decision
+    occurred_in: ["task:x", "task:y"]
+    severity: high
+hypotheses:
+  - text: "\u3053\u306e\u9045\u5ef6\u306f\u8a2d\u8a08\u5de5\u7a0b\u306e\u5c5e\u4eba\u6027\u304c\u539f\u56e0\u3067\u3042\u308b\u53ef\u80fd\u6027\u304c\u9ad8\u3044"
+    confidence: 0.7
 
 ```
 **Tips:**

--- a/patterns/remote-island-telemedicine.yaml
+++ b/patterns/remote-island-telemedicine.yaml
@@ -39,3 +39,25 @@ evidence:
 access:
   uri: https://github.com/ak2i/ideamark-core/blob/main/patterns/remote-island-telemedicine.yaml
   visibility: public
+timeline:
+  - entity: task:telemedicine-setup
+    year: 2023
+    milestone: infrastructure buildout
+    status: completed
+dependencies:
+  - from: task:network-upgrade
+    to: task:telemedicine-setup
+    type: sequential
+    risk: medium
+observed_metrics:
+  - entity: task:patient-wait-time
+    metric: minutes
+    average: "15"
+    stdev: "5"
+patterns:
+  - type: delayed-decision
+    occurred_in: ["task:funding"]
+    severity: high
+hypotheses:
+  - text: Staff training delays may increase patient wait time
+    confidence: 0.6

--- a/schema/ideamark.schema.yaml
+++ b/schema/ideamark.schema.yaml
@@ -200,3 +200,68 @@ properties:
             - session
           contact:
             type: string
+  timeline:
+    type: array
+    items:
+      type: object
+      properties:
+        entity:
+          type: string
+        year:
+          type: integer
+        milestone:
+          type: string
+        status:
+          type: string
+      required:
+      - entity
+      - year
+      - milestone
+  dependencies:
+    type: array
+    items:
+      type: object
+      properties:
+        from:
+          type: string
+        to:
+          type: string
+        type:
+          type: string
+        risk:
+          type: string
+  observed_metrics:
+    type: array
+    items:
+      type: object
+      properties:
+        entity:
+          type: string
+        metric:
+          type: string
+        average:
+          type: string
+        stdev:
+          type: string
+  patterns:
+    type: array
+    items:
+      type: object
+      properties:
+        type:
+          type: string
+        occurred_in:
+          type: array
+          items:
+            type: string
+        severity:
+          type: string
+  hypotheses:
+    type: array
+    items:
+      type: object
+      properties:
+        text:
+          type: string
+        confidence:
+          type: number


### PR DESCRIPTION
## Summary
- document new project-analysis structures
- extend example pattern with timeline, dependencies, observed metrics, patterns and hypotheses
- update format guides with extended snippet
- support new fields in IdeaMark schema

## Testing
- `python test_health.py`
- `python test_jwt.py`
- `python lib/mcp_server/test_imports.py`
- `python lib/mcp_server/test_api.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_687d60da14e88322bb326e8d2df629a4